### PR TITLE
docs(readme): agregar sección Colaboradores con roles y enlaces (fixes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Agradecemos a todas las personas que han colaborado en el proyecto 🙌
 - [@Ariel-GonzAguer](https://github.com/Ariel-GonzAguer) — Propietario / Mantenedor  
 - [@lianyvar](https://github.com/lianyvar) — Colaboradora  
 - [@mvlsqz](https://github.com/mvlsqz) — Colaborador  
+- [@nadir-ammisaid](https://github.com/nadir-ammisaid) — Colaborador  
 - [@astrobot-houston](https://github.com/astrobot-houston) — Bot (automatización)
 
  ## 🎯 Objetivos del proyecto


### PR DESCRIPTION
# Plantilla para Pull Request

## Descripción

Este PR agrega la sección **Colaboradores** justo debajo de la cabecera principal del README, con nombres, roles y enlaces a perfiles, tal como solicita el issue #29.  

Resuelve: #29

## Cambios realizados

- [x] Documentación

## Checklist

- [x] El código sigue la guía de estilo del proyecto  
- [x] Se verificó manualmente que el cambio es correcto  
- [x] La documentación fue actualizada  
- [x] No se incluyen datos sensibles ni credenciales  
- [x] Se ejecutó `npm run lint` antes de enviar el PR  

## Notas adicionales

N/A
