### PR TITLE
fix(toast): corregir barra verde visible en el lado derecho

### DIFF
--- a/src/components/Toast.astro
+++ b/src/components/Toast.astro
@@ -4,7 +4,7 @@
 
 <div
   id="toast"
-  class="fixed top-4 right-4 bg-green-500 text-white px-6 py-3 rounded-md shadow-lg transform translate-x-full transition-transform duration-300 ease-in-out"
+  class="fixed top-4 right-4 bg-green-500 text-white px-6 py-3 rounded-md shadow-lg transform translate-x-[calc(100%+2rem)] transition-transform duration-300 ease-in-out z-50"
   role="alert"
   aria-live="polite"
 >

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -20,7 +20,7 @@ export function showToast(message, isError = false) {
   toast.style.transform = "translateX(0)";
 
   setTimeout(() => {
-    toast.style.transform = "translateX(100%)";
+    toast.style.transform = "translateX(calc(100% + 2rem))";
   }, 3000);
 }
 


### PR DESCRIPTION
## Descripción
Corrige el bug visual donde aparecía una barra verde en el lado derecho de la pantalla que seguía el scroll. El problema era causado por el componente Toast que no estaba completamente oculto.

## Cambios realizados
- [x] Corrección de bug

**Detalles de los cambios:**
- Cambiar `translate-x-full` a `translate-x-[calc(100%+2rem)]` en Toast.astro
- Actualizar función showToast en utils.js para usar `calc(100% + 2rem)`
- Agregar `z-50` para mejor control de z-index
- Mantener funcionalidad completa del sistema de notificaciones

## Checklist
- [x] El código sigue la guía de estilo del proyecto
- [x] Se agregaron pruebas o se verificó manualmente
- [x] La documentación fue actualizada/agregada (si aplica)
- [x] No se incluyen datos sensibles ni credenciales
- [x] Se ejecutó `npm run lint` antes de enviar el PR

## Notas adicionales

**Testing realizado:**
- Verificado que la barra verde ya no aparece
- Confirmado que las notificaciones toast siguen funcionando correctamente
- Probado en diferentes tamaños de pantalla

**Archivos modificados:**
- `src/components/Toast.astro` - Ajuste de posicionamiento
- `src/scripts/utils.js` - Consistencia en la lógica JavaScript